### PR TITLE
set graphics_backend

### DIFF
--- a/graphics/README.md
+++ b/graphics/README.md
@@ -87,6 +87,7 @@ The lib.zig in this graphics module provides simple helpers for you add the pack
 // cosmic repo should be a subdirectory.
 const std = @import("std");
 const graphics = @import("cosmic/graphics/lib.zig");
+const backend = @import("cosmic/platform/backend.zig");
 
 pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
@@ -97,8 +98,9 @@ pub fn build(b: *std.build.Builder) void {
     exe.setTarget(target);
     exe.setBuildMode(mode);
 
-    graphics.addPackage(exe, .{});
-    graphics.buildAndLink(exe, .{});
+    const graphics_backend = backend.getGraphicsBackend(exe);
+    graphics.addPackage(exe, .{.graphics_backend = graphics_backend});
+    graphics.buildAndLink(exe, .{.graphics_backend = graphics_backend});
 
     exe.setOutputDir("zig-out");
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -70,6 +70,7 @@ The lib.zig in this ui module provides simple helpers for you add the package, b
 // cosmic repo should be a subdirectory.
 const std = @import("std");
 const ui = @import("cosmic/ui/lib.zig");
+const backend = @import("cosmic/platform/backend.zig");
 
 pub fn build(b: *std.build.Builder) void {
     const target = b.standardTargetOptions(.{});
@@ -80,8 +81,9 @@ pub fn build(b: *std.build.Builder) void {
     exe.setTarget(target);
     exe.setBuildMode(mode);
 
-    ui.addPackage(exe, .{});
-    ui.buildAndLink(exe, .{});
+    const graphics_backend = backend.getGraphicsBackend(exe);
+    ui.addPackage(exe, .{.graphics_backend = graphics_backend});
+    ui.buildAndLink(exe, .{.graphics_backend = graphics_backend});
 
     exe.setOutputDir("zig-out");
 

--- a/ui/lib.zig
+++ b/ui/lib.zig
@@ -52,8 +52,7 @@ pub fn addPackage(step: *std.build.LibExeObjStep, opts: Options) void {
 }
 
 pub fn buildAndLink(step: *std.build.LibExeObjStep, opts: Options) void {
-    _ = opts;
-    graphics.buildAndLink(step, .{});
+    graphics.buildAndLink(step, .{.graphics_backend = opts.graphics_backend});
 }
 
 fn srcPath() []const u8 {


### PR DESCRIPTION
now `graphics_backend` option value seems to be required.

```
./build.zig:24:31: error: missing field: 'graphics_backend'
    graphics.addPackage(exe, .{});
```

```
./libs/cosmic/ui/lib.zig:56:34: error: missing field: 'graphics_backend'
    graphics.buildAndLink(step, .{});
```
